### PR TITLE
Feature/folder structure

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,10 @@
-// Place your settings in this file to overwrite default and user settings.
 {
     "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
+        "out": false
     },
     "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
+        "out": true
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
-    "cSpell.words": [
-        "backticks",
-        "cmodel",
-        "configurator",
-        "curlies"
-    ]
 }

--- a/package.json
+++ b/package.json
@@ -72,15 +72,17 @@
 		"@types/mocha": "^2.2.42",
 		"@types/node": "^10.12.21",
 		"@types/open": "^6.0.0",
+		"@types/pretty": "^2.0.0",
+		"@types/rimraf": "^2.0.2",
 		"tslint": "^5.12.1",
 		"typescript": "^3.3.1",
 		"vscode": "^1.1.28"
 	},
 	"dependencies": {
-		"@types/rimraf": "^2.0.2",
 		"express": "^4.16.4",
 		"lodash.escape": "^4.0.1",
 		"open": "^6.0.0",
+		"pretty": "^2.0.0",
 		"rimraf": "^2.6.3"
 	}
 }

--- a/src/core/ApexDoc.ts
+++ b/src/core/ApexDoc.ts
@@ -95,7 +95,7 @@ class ApexDoc {
             // we are done!
             const endElapsed = performance.now();
             vscode.window.showInformationMessage(
-                `ApexDoc2 complete! ${numProcessed} Apex files processed in ${endElapsed - beginElapsed} ms.`
+                `ApexDoc2 complete! ${numProcessed} Apex files processed in ${(endElapsed - beginElapsed).toFixed(2)} ms.`
             );
         } catch (err) {
             throw err;
@@ -275,7 +275,7 @@ class ApexDoc {
                 // enum, we must be dealing with a class level enum and
                 // should return early, otherwise we're dealing with
                 // an inner enum and should add to our class model.
-                if (cModel && cModels.length === 0) {
+                if (!cModel && cModels.length === 0) {
                     return eModel;
                 } else {
                     cModel && cModel.getEnums().push(eModel);

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import ApexDoc from './ApexDoc';
+import Guards from '../utils/Guards';
 
 export interface IApexDocConfig {
 	sourceDirectory: string;
@@ -59,7 +60,13 @@ class Config implements IApexDocConfig {
         this.sortOrder = ApexDoc.ORDER_ALPHA;
     }
 
-    public static merge(userConfig: IApexDocConfig): IApexDocConfig {
+    public static getConfig(): IApexDocConfig {
+        return this.merge({
+            ...vscode.workspace.getConfiguration('apexdoc2')['config']
+        });
+    }
+
+    private static merge(userConfig: IApexDocConfig): IApexDocConfig {
         const defaults = new Config();
 
         return {
@@ -72,6 +79,29 @@ class Config implements IApexDocConfig {
                 ? defaults.targetDirectory
                 : userConfig.targetDirectory
         };
+    }
+
+    public static validateConfig(config: IApexDocConfig): void {
+        // misc. strings
+        config.title = Guards.title(config.title);
+        config.sortOrder = Guards.sortOrder(config.sortOrder);
+        config.sourceControlURL = Guards.sourceControlURL(config.sourceControlURL);
+
+        // arrays
+        config.scope = Guards.scope(config.scope);
+        config.assets = Guards.stringArray(config.assets, 'assets');
+        config.includes = Guards.stringArray(config.includes, 'includes');
+        config.excludes = Guards.stringArray(config.excludes, 'excludes');
+
+        // booleans
+        config.cleanDir = Guards.boolGuard(config.cleanDir, false);
+        config.showTOCSnippets = Guards.boolGuard(config.showTOCSnippets, true);
+
+        // directories
+        config.targetDirectory = Guards.targetDirectory(config.targetDirectory);
+        config.homePagePath = Guards.directory(config.homePagePath, 'homePagePath');
+        config.bannerPagePath = Guards.directory(config.bannerPagePath, 'bannerPagePath');
+        config.sourceDirectory = Guards.directory(config.sourceDirectory, 'sourceDirectory');
     }
 }
 

--- a/src/core/DocGen.ts
+++ b/src/core/DocGen.ts
@@ -1,4 +1,4 @@
-import * as HTML from '../utils/Templates';
+import * as templates from '../utils/Templates';
 import ApexDoc from './ApexDoc';
 import ApexDocError from '../utils/ApexDocError';
 import ApexModel from '../models/ApexModel';
@@ -17,7 +17,7 @@ class DocGen {
 
     public static documentClass(cModel: ClassModel, modelMap: Map<string, TopLevelModel>): string {
         const hasSource = this.sourceControlURL ? true : false;
-        const sourceLinkIcon = hasSource ? `<span>${HTML.EXTERNAL_LINK}</span>` : '';
+        const sourceLinkIcon = hasSource ? `<span>${templates.EXTERNAL_LINK}</span>` : '';
         const sectionSourceLink = this.maybeMakeSourceLink(cModel, cModel.getTopmostClassName(), this.escapeHTML(cModel.getName(), false));
         const header = `<h2 class="sectionTitle" id="${cModel.getName()}">${sectionSourceLink + sourceLinkIcon}</h2>`;
 
@@ -40,7 +40,7 @@ class DocGen {
 
     public static documentEnum(eModel: EnumModel, modelMap: Map<string, TopLevelModel>): string {
         const hasSource = this.sourceControlURL ? true : false;
-        const sourceLinkIcon = hasSource ? `<span>${HTML.EXTERNAL_LINK}</span>` : '';
+        const sourceLinkIcon = hasSource ? `<span>${templates.EXTERNAL_LINK}</span>` : '';
         const sectionSourceLink = this.maybeMakeSourceLink(eModel, eModel.getName(), this.escapeHTML(eModel.getName(), false));
         let contents = `<h2 class="sectionTitle" id="${eModel.getName()}">${sectionSourceLink + sourceLinkIcon}</h2>`;
 
@@ -412,9 +412,9 @@ class DocGen {
         let header =  '<html><head><title>' + documentTitle + '</title>';
 
         if (bannerPage) {
-            header += HTML.HEADER_OPEN + bannerPage;
+            header += templates.HEADER_OPEN + bannerPage;
         } else {
-            header += HTML.HEADER_OPEN + HTML.PROJECT_DETAIL + HTML.HEADER_CLOSE;
+            header += templates.HEADER_OPEN + templates.PROJECT_DETAIL + templates.HEADER_CLOSE;
         }
 
         return header;

--- a/src/core/DocGen.ts
+++ b/src/core/DocGen.ts
@@ -409,12 +409,12 @@ class DocGen {
     }
 
     public static makeHeader(bannerPage: string, documentTitle: string): string {
-        let header =  '<html><head><title>' + documentTitle + '</title>';
+        let header: string;
 
         if (bannerPage) {
-            header += templates.HEADER_OPEN + bannerPage;
+            header = templates.headerOpen(documentTitle) + bannerPage;
         } else {
-            header += templates.HEADER_OPEN + templates.PROJECT_DETAIL + templates.HEADER_CLOSE;
+            header = templates.headerOpen(documentTitle) + templates.PROJECT_DETAIL + templates.HEADER_CLOSE;
         }
 
         return header;

--- a/src/core/DocGen.ts
+++ b/src/core/DocGen.ts
@@ -362,19 +362,15 @@ class DocGen {
     }
 
     private static wrapInlineCode(html: string): string {
-        const words = html.split(/\b\s{1,2}\b/)
-            .map(word => {
-                let firstIndex = word.indexOf(' ');
-                let lastIndex = word.lastIndexOf(' ');
-                if (firstIndex > -1 && lastIndex > -1 && firstIndex !== lastIndex) {
-                    word = word.replace('`', `<code class="inlineCode">`);
-                    word = word.replace('`', '</code>');
-                    return word;
-                }
-                return word;
+        const codeWords: RegExpMatchArray | null = html.match(/(`|&#96;).+?(`|&#96;)/g);
+        if (codeWords) {
+            codeWords.forEach(word => {
+                let codeWord = word.replace(/&#96;|`/, `<code class="inlineCode">`);
+                codeWord = codeWord.replace(/&#96;|`/, '</code>');
+                html = html.replace(word, codeWord);
             });
-
-        return words.join(' ');
+        }
+        return html;
     }
 
     public static makeHTMLScopingPanel(): string {

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -109,7 +109,7 @@ class FileManager {
         // create dir if it doesn't exist
         if (!existsSync(this.path)) {
             mkdirSync(this.path);
-        } else if (ApexDoc.cleanDir) {
+        } else if (ApexDoc.config.cleanDir) {
             rimraf.sync(resolve(...[this.path, '*']));
         }
 

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -7,6 +7,7 @@ import ClassModel from '../models/ClassModel';
 import DocGen from './DocGen';
 import EnumModel from '../models/EnumModel';
 import LineReader from '../utils/LineReader';
+import pretty from 'pretty';
 import rimraf from 'rimraf';
 import TopLevelModel, { ModelType } from '../models/TopLevelModel';
 import { basename, resolve } from 'path';
@@ -115,7 +116,7 @@ class FileManager {
 
         // create our HTML files
         for (let fileName of fileMap.keys()) {
-            let contents = fileMap.get(fileName);
+            let contents = pretty(<string>fileMap.get(fileName), { ocd: true });
             let fullyQualifiedFileName = resolve(...[this.path, fileName + '.html']);
             writeFileSync(fullyQualifiedFileName, contents);
         }

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -37,12 +37,12 @@ class FileManager {
         if (files && files.some(file => file.endsWith('cls'))) {
             files.forEach(fileName => {
                 // make sure entry is a file and is an apex cl
-                if (!fileName.endsWith(".cls")) {
+                if (!fileName.endsWith('.cls')) {
                     return;
                 }
 
                 for (let entry of excludes) {
-                    entry = entry.trim().replace("*", "");
+                    entry = entry.trim().replace('*', '');
                     // file is explicitly excluded or matches wildcard, return early
                     if (fileName.startsWith(entry) || fileName.endsWith(entry))  {
                         return;
@@ -57,7 +57,7 @@ class FileManager {
 
                 // there are includes params, only include files that pass test
                 for (let entry of includes) {
-                    entry = entry.trim().replace("*", "");
+                    entry = entry.trim().replace('*', '');
                     // file matches explicitly matches or matches wildcard
                     if (fileName.startsWith(entry) || fileName.endsWith(entry))  {
                         filesToCopy.push(fileName);
@@ -106,33 +106,17 @@ class FileManager {
     }
 
     private createHTML(fileMap: Map<string, string>): void {
-        // create our target directory if it doesn't exist
-
-        // TODO: rework so class files go in 'pages' directory!!!
-        // this will also require assets to go in their own directory
-        // and to update the references in the HTML templates. Also
-        // will need to update goToLocation destination references and
-        // makeSeeLink to account for new folder structure.
+        // create dir if it doesn't exist
         if (!existsSync(this.path)) {
             mkdirSync(this.path);
-            // mkdirSync(resolve(...[this.path, 'pages']));
         } else if (ApexDoc.cleanDir) {
-            let cleanRoot = resolve(...[this.path + '*']);
-            // let cleanPages = resolve(...[this.path, 'pages/*']);
-            rimraf.sync(cleanRoot);
-            // rimraf.sync(cleanPages);
+            rimraf.sync(resolve(...[this.path, '*']));
         }
 
+        // create our HTML files
         for (let fileName of fileMap.keys()) {
-            let fullyQualifiedFileName;
             let contents = fileMap.get(fileName);
-
-            // if (fileName === 'index') {
-                fullyQualifiedFileName = resolve(...[this.path, fileName + '.html']);
-            // } else {
-                // fullyQualifiedFileName = resolve(...[this.path, 'pages', fileName + '.html']);
-            // }
-
+            let fullyQualifiedFileName = resolve(...[this.path, fileName + '.html']);
             writeFileSync(fullyQualifiedFileName, contents);
         }
     }
@@ -157,7 +141,6 @@ class FileManager {
             homeContents = DocGen.makeHeader(bannerPage, this.documentTitle) + homeContents + templates.FOOTER;
         }
 
-        let fileName = '';
         const fileMap = new Map<string, string>();
         fileMap.set('index', homeContents);
 
@@ -165,6 +148,7 @@ class FileManager {
         this.createClassGroupContent(fileMap, links, bannerPage, groupNameMap);
 
         for (let model of models) {
+            let fileName = '';
             let contents = links;
             if (model.getNameLine()) {
                 fileName = model.getName();
@@ -192,14 +176,13 @@ class FileManager {
             } else {
                 continue;
             }
+
             contents += '</div>';
             contents = DocGen.makeHeader(bannerPage, this.documentTitle) + contents + templates.FOOTER;
             fileMap.set(fileName, contents);
         }
 
-        // generate our HTML output files
         this.createHTML(fileMap);
-        // copy ApexDoc assets to our target dir
         this.copyAssetsToTarget(this.collectApexDocAssets());
         // copy user assets last, if they are using a favicon
         // this will override the default provided by ApexDoc2

--- a/src/core/FileManager.ts
+++ b/src/core/FileManager.ts
@@ -1,4 +1,4 @@
-import * as HTML from '../utils/Templates';
+import * as templates from '../utils/Templates';
 import * as vscode from 'vscode';
 import ApexDoc from './ApexDoc';
 import ApexDocError from '../utils/ApexDocError';
@@ -105,18 +105,34 @@ class FileManager {
         return '';
     }
 
-    private createHTML(fileNameToContent: Map<string, string>): void {
+    private createHTML(fileMap: Map<string, string>): void {
         // create our target directory if it doesn't exist
+
+        // TODO: rework so class files go in 'pages' directory!!!
+        // this will also require assets to go in their own directory
+        // and to update the references in the HTML templates. Also
+        // will need to update goToLocation destination references and
+        // makeSeeLink to account for new folder structure.
         if (!existsSync(this.path)) {
             mkdirSync(this.path);
+            // mkdirSync(resolve(...[this.path, 'pages']));
         } else if (ApexDoc.cleanDir) {
-            let clean = resolve(...[this.path + '*']);
-            rimraf.sync(clean);
+            let cleanRoot = resolve(...[this.path + '*']);
+            // let cleanPages = resolve(...[this.path, 'pages/*']);
+            rimraf.sync(cleanRoot);
+            // rimraf.sync(cleanPages);
         }
 
-        for (let fileName of fileNameToContent.keys()) {
-            let contents = fileNameToContent.get(fileName);
-            let fullyQualifiedFileName = resolve(...[this.path, fileName + '.html']);
+        for (let fileName of fileMap.keys()) {
+            let fullyQualifiedFileName;
+            let contents = fileMap.get(fileName);
+
+            // if (fileName === 'index') {
+                fullyQualifiedFileName = resolve(...[this.path, fileName + '.html']);
+            // } else {
+                // fullyQualifiedFileName = resolve(...[this.path, 'pages', fileName + '.html']);
+            // }
+
             writeFileSync(fullyQualifiedFileName, contents);
         }
     }
@@ -134,11 +150,11 @@ class FileManager {
 
         if (homeContents) {
             homeContents = links + `<td class='contentTD'><h2 class='sectionTitle'>Home</h2>${homeContents}</td>`;
-            homeContents = DocGen.makeHeader(bannerPage, this.documentTitle) + homeContents + HTML.FOOTER;
+            homeContents = DocGen.makeHeader(bannerPage, this.documentTitle) + homeContents + templates.FOOTER;
         } else {
-            homeContents = HTML.DEFAULT_HOME_CONTENTS;
+            homeContents = templates.DEFAULT_HOME_CONTENTS;
             homeContents = links + `<td class='contentTD'><h2 class='sectionTitle'>Home</h2>${homeContents}</td>`;
-            homeContents = DocGen.makeHeader(bannerPage, this.documentTitle) + homeContents + HTML.FOOTER;
+            homeContents = DocGen.makeHeader(bannerPage, this.documentTitle) + homeContents + templates.FOOTER;
         }
 
         let fileName = '';
@@ -177,7 +193,7 @@ class FileManager {
                 continue;
             }
             contents += '</div>';
-            contents = DocGen.makeHeader(bannerPage, this.documentTitle) + contents + HTML.FOOTER;
+            contents = DocGen.makeHeader(bannerPage, this.documentTitle) + contents + templates.FOOTER;
             fileMap.set(fileName, contents);
         }
 
@@ -206,7 +222,7 @@ class FileManager {
                         ${DocGen.escapeHTML(cg.getName(), false)}
                         </h2>${cgContent}</td>`;
 
-                    html += HTML.FOOTER;
+                    html += templates.FOOTER;
 
                     fileMap.set(cg.getContentFilename(), html);
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,17 +4,13 @@ import Configurator, { IApexDocConfig } from './core/Config';
 import Guards from './utils/Guards';
 import { closeServer, createDocServer } from './server';
 
-function getConfig(): IApexDocConfig {
-	return Configurator.merge({
-		...vscode.workspace.getConfiguration('apexdoc2')['config']
-	});
-}
-
 export function activate(context: vscode.ExtensionContext) {
 	// main ApexDoc2 command
 	let runApexDoc2 = vscode.commands.registerCommand('extension.runApexDoc2', () => {
 		try {
-			const config: IApexDocConfig = getConfig();
+			const config: IApexDocConfig = Configurator.getConfig();
+			Configurator.validateConfig(config);
+
 			ApexDoc.extensionRoot = context.extensionPath;
 			ApexDoc.runApexDoc(config);
 		} catch (e) {
@@ -26,8 +22,8 @@ export function activate(context: vscode.ExtensionContext) {
 	// serve created docs over HTTP on local host
 	let serveDocs = vscode.commands.registerCommand('extension.serveDocs', () => {
 		try {
-			const config: IApexDocConfig = getConfig();
-			createDocServer(config.targetDirectory, config.title, Guards.portGuard(config.port));
+			const config: IApexDocConfig = Configurator.getConfig();
+			createDocServer(config.targetDirectory, config.title, Guards.port(config.port));
 		} catch (e) {
 			console.log(e);
 			vscode.window.showErrorMessage(e.message);

--- a/src/models/ApexModel.ts
+++ b/src/models/ApexModel.ts
@@ -216,7 +216,7 @@ abstract class ApexModel {
     // make sure path relative to target
     // directory exists for @group-content token
     private pathExists(contentPath: string): boolean {
-        let path = resolve(...[ApexDoc.sourceDirectory, contentPath.trim()]);
+        let path = resolve(...[ApexDoc.config.sourceDirectory, contentPath.trim()]);
         if (/.*\.s?html?$/.test(contentPath.trim()) && existsSync(path)) {
             return true;
         } else {

--- a/src/models/ApexModel.ts
+++ b/src/models/ApexModel.ts
@@ -217,7 +217,6 @@ abstract class ApexModel {
     // directory exists for @group-content token
     private pathExists(contentPath: string): boolean {
         let path = resolve(...[ApexDoc.sourceDirectory, contentPath.trim()]);
-        // TODO: need to test for HTMLD here as well!
         if (/.*\.s?html?$/.test(contentPath.trim()) && existsSync(path)) {
             return true;
         } else {

--- a/src/models/ClassModel.ts
+++ b/src/models/ClassModel.ts
@@ -120,18 +120,18 @@ class ClassModel extends TopLevelModel {
 
     public getName(): string {
         let nameLine = this.getNameLine();
-        let parent = !this.cmodelParent ? '' : this.cmodelParent.getName() + ".";
+        let parent = !this.cmodelParent ? '' : this.cmodelParent.getName() + '.';
 
         if (nameLine) {
             nameLine = nameLine.trim();
         }
 
         if (nameLine && nameLine.trim().length > 0) {
-            let keywordAt = nameLine.toLowerCase().indexOf(ApexDoc.CLASS + " ");
+            let keywordAt = nameLine.toLowerCase().indexOf(ApexDoc.CLASS + ' ');
 
             let offset = 6;
             if (keywordAt === -1) {
-                keywordAt = nameLine.toLowerCase().indexOf(ApexDoc.INTERFACE + " ");
+                keywordAt = nameLine.toLowerCase().indexOf(ApexDoc.INTERFACE + ' ');
                 offset = 10;
             }
 
@@ -149,7 +149,7 @@ class ClassModel extends TopLevelModel {
                 let name = nameLine.substring(0, spaceAt);
                 return (parent + name).trim();
             } catch (ex) {
-                return (parent + nameLine.substring(nameLine.lastIndexOf(" ") + 1)).trim();
+                return (parent + nameLine.substring(nameLine.lastIndexOf(' ') + 1)).trim();
             }
         } else {
             return '';

--- a/src/utils/ApexDocError.ts
+++ b/src/utils/ApexDocError.ts
@@ -1,31 +1,31 @@
 class ApexDocError extends Error {
     public static INVALID_SCOPE = 'Please provide an array of valid scopes. Valid scopes include: global, public, protected, private, testMethod, and webService';
-    public static SCOPE_ENTRIES_MAX = 'Argument <scope> has too many entries. ' + ApexDocError.INVALID_SCOPE;
-    public static SCOPE_ENTRIES_MIN = 'Argument <scope> must have at least one entry. ' + ApexDocError.INVALID_SCOPE;
+    public static SCOPE_ENTRIES_MAX = '<scope> parameter has too many entries. ' + ApexDocError.INVALID_SCOPE;
+    public static SCOPE_ENTRIES_MIN = '<scope> parameter must have at least one entry. ' + ApexDocError.INVALID_SCOPE;
 
     public static INVALID_DIRECTORY = (arg: string, path: string) =>
-        `Value for <${arg}> argument: '${path}' is invalid. Please provide a valid directory.`
+        `Value for <${arg}> parameter: '${path}' is invalid. Please provide a valid directory.`
 
     public static INVALID_SORT_ORDER = (sortOrder: string) =>
-        `Value for <sort_order> argument '${sortOrder}' is invalid. Options for this argument are: 'logical' or 'alpha'.`
+        `Value for <sortOrder> parameter '${sortOrder}' is invalid. Options for this parameter are: 'logical' or 'alpha'.`
 
     public static INVALID_PORT = (port: number) =>
-        `Value for <port> argument '${port}' is invalid. Please provide a valid port number.`
+        `Value for <port> parameter '${port}' is invalid. Please provide a valid port number.`
 
     public static INVALID_SOURCE_URL = (url: string) =>
-        `Value for <source_url> argument '${url}' is invalid. Please provide a valid URL where your source ` +
+        `Value for <sourceControlURL> parameter '${url}' is invalid. Please provide a valid URL where your source ` +
         'code is hosted, e.g.: \'https://github.com/no-stack-dub-sack/salesforce-project/tree/master/src/classes\''
 
     public static INVALID_TARGET_DIRECTORY = (path: string) =>
-        `Value for <target_directory> argument: '${path}' is invalid. Please provide a valid path.`
+        `Value for <targetDirectory> parameter: '${path}' is invalid. Please provide a valid path.`
 
-    public static ONLY_STRINGS = (arg: string) => `Argument <${arg}> array may only contain strings.`;
+    public static ONLY_STRINGS = (arg: string) => `<${arg}> parameter's array may only contain strings.`;
 
     public static SCOPE_ENTRY_INVALID = (entry: string) =>
-        `Entry for <scope> argument: '${entry}' is invalid. ${ApexDocError.INVALID_SCOPE}`
+        `Entry for <scope> parameter: '${entry}' is invalid. ${ApexDocError.INVALID_SCOPE}`
 
     public static INVALID_TYPE = (arg: string, type: string) =>
-        `Value for <${arg}> argument is incorrect type. Expected '${type}'`
+        `Value for <${arg}> parameter is incorrect type. Expected '${type}'`
 
     public static NO_FILES_FOUND = (sourceDir: string) => `No Apex files found in directory: ${sourceDir}`;
 

--- a/src/utils/Guards.ts
+++ b/src/utils/Guards.ts
@@ -16,8 +16,17 @@ class Guards {
         }
     }
 
+    public static targetDirectory(path: string): string {
+        this.typeGuard('string', path, 'targetDirectory');
+        if (path && path.length > 0) {
+            return path;
+        } else {
+            throw new ApexDocError(ApexDocError.INVALID_TARGET_DIRECTORY(path));
+        }
+    }
+
     public static sortOrder(sortOrder: string): string {
-        this.typeGuard('string', sortOrder, 'sort_order');
+        this.typeGuard('string', sortOrder, 'sortOrder');
         sortOrder = sortOrder.toLowerCase();
         if (sortOrder === ApexDoc.ORDER_LOGICAL || sortOrder === ApexDoc.ORDER_ALPHA) {
             return sortOrder;
@@ -26,7 +35,12 @@ class Guards {
         }
     }
 
-    public static portGuard(port: number): number {
+    public static title(title: string): string {
+        this.typeGuard('string', title, 'title');
+        return title ? title : 'Apex Documentation';
+    }
+
+    public static port(port: number): number {
         this.typeGuard('number', port, 'port');
         // only allows integers between 0-65535 as port numbers
         if (/^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/.test(String(port))) {
@@ -36,8 +50,8 @@ class Guards {
         }
     }
 
-    public static sourceURL(str: string): string {
-        this.typeGuard('string', str, 'source_url');
+    public static sourceControlURL(str: string): string {
+        this.typeGuard('string', str, 'sourceControlURL');
         if (str === '' || Utils.isURL(str)) {
             return str.trim();
         } else {
@@ -45,39 +59,22 @@ class Guards {
         }
     }
 
-    public static targetDirectory(path: string): string {
-        this.typeGuard('string', path, 'target_directory');
-        if (path && path.length > 0) {
-            return path;
-        } else {
-            throw new ApexDocError(ApexDocError.INVALID_TARGET_DIRECTORY(path));
-        }
-    }
-
-    public static showTOCSnippets(bool: boolean): boolean {
+    public static boolGuard(bool: boolean, defaultValue: boolean): boolean {
         if (typeof bool !== 'boolean') {
-            return true; // DEFAULT
+            return defaultValue;
         } else {
             return bool;
         }
     }
 
-    public static cleanDir(bool: boolean): boolean {
-        if (typeof bool !== 'boolean') {
-            return false; // DEFAULT
-        } else {
-            return bool;
-        }
-    }
-
-    public static assets(assets: string[]): string[] {
-        this.typeGuard('array', assets, 'assets');
-        assets.forEach(resource => {
-            if (typeof resource !== 'string') {
-                throw new ApexDocError(ApexDocError.ONLY_STRINGS('assets'));
+    public static stringArray(arr: string[], argName: string): string[] {
+        this.typeGuard('array', arr, argName);
+        arr.forEach(item => {
+            if (typeof item !== 'string') {
+                throw new ApexDocError(ApexDocError.ONLY_STRINGS(argName));
             }
         });
-        return assets;
+        return arr;
     }
 
     public static scope(scopes: string[]): string[] {

--- a/src/utils/Templates.ts
+++ b/src/utils/Templates.ts
@@ -1,15 +1,13 @@
 export const headerOpen = (documentTitle: string) => {
-    return  `
-        <!DOCTYPE html>
-        <html lang="en">
+    return  `<html lang="en">
         <head>
             <title>${documentTitle}</title>
             <meta charset="UTF-8">
-            <script type="text/javascript" src="index.js"></script>
-            <script charset="UTF-8" src="highlight.js"></script>
-            <link rel="stylesheet" href="highlight.css" />
-            <link rel="stylesheet" type="text/css" href="index.css" />
-            <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+            <script type="text/javascript" src="./assets/index.js"></script>
+            <script charset="UTF-8" src="./assets/highlight.js"></script>
+            <link rel="stylesheet" href="./assets/highlight.css" />
+            <link rel="stylesheet" type="text/css" href="./assets/index.css" />
+            <link rel="shortcut icon" type="image/png" href="./assets/favicon.png"/>
         </head>
         <body>`;
 };

--- a/src/utils/Templates.ts
+++ b/src/utils/Templates.ts
@@ -1,23 +1,47 @@
-export const HEADER_OPEN =
-    `<script type="text/javascript" src="index.js"></script>
-    <meta charset="UTF-8">
-    <link rel="stylesheet" href="highlight.css">
-    <script charset="UTF-8" src="highlight.js"></script>
-    <link rel="stylesheet" type="text/css" href="index.css" />
-    <link rel="shortcut icon" type="image/png" href="favicon.png"/>
-    </head><body>`;
+export const headerOpen = (documentTitle: string) => {
+    return  `<html>
+        <head>
+            <title>${documentTitle}</title>
+            <meta charset="UTF-8">
+            <script type="text/javascript" src="index.js"></script>
+            <script charset="UTF-8" src="highlight.js"></script>
+            <link rel="stylesheet" href="highlight.css" />
+            <link rel="stylesheet" type="text/css" href="index.css" />
+            <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+        </head>
+        <body>`;
+};
 
 export const PROJECT_DETAIL =
-    `<div class="topsection">
-    <table><tr><td><img src="apex_doc_2_logo.png" style="height: 90px; margin-left: 5px;"/></td>
-    <td><h2 style="margin: -15px 0 0 0;">ApexDoc2 | Apex Documentation</h2>Check out the GitHub project at:<br/>
-    <a href="https://github.com/no-stack-dub-sack/ApexDoc2">https://github.com/no-stack-dub-sack/ApexDoc2</a><br/>`;
+`<div class="topsection">
+    <table>
+        <tr>
+            <td>
+                <img src="apex_doc_2_logo.png" style="height: 90px; margin-left: 5px;"/>
+            </td>
+            <td>
+                <h2 style="margin: -15px 0 0 0;">ApexDoc2 | Apex Documentation</h2>Check out the GitHub project at:<br/>
+                <a href="https://github.com/no-stack-dub-sack/ApexDoc2-VSCode">
+                    https://github.com/no-stack-dub-sack/ApexDoc2-VSCode
+                </a>
+                <br/>`;
 
 export const HEADER_CLOSE = `</td></tr></table></div>`;
 
-export const FOOTER = `</div></div></td></tr></table><hr/>
-    <center class="footer"><a href="https://github.com/no-stack-dub-sack/ApexDoc2-VSCode" target="_blank">Powered By ApexDoc2</a>
-    </center></body></html>`;
+export const FOOTER =
+                    `</div>
+                </div>
+            </td>
+        </tr>
+    </table>
+    <hr/>
+    <center class="footer">
+        <a href="https://github.com/no-stack-dub-sack/ApexDoc2-VSCode" target="_blank">
+            Powered By ApexDoc2
+        </a>
+    </center>
+</body>
+</html>`;
 
 export const DEFAULT_HOME_CONTENTS = `<h2>Project Home</h2>`;
 

--- a/src/utils/Templates.ts
+++ b/src/utils/Templates.ts
@@ -1,5 +1,7 @@
 export const headerOpen = (documentTitle: string) => {
-    return  `<html>
+    return  `
+        <!DOCTYPE html>
+        <html lang="en">
         <head>
             <title>${documentTitle}</title>
             <meta charset="UTF-8">

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -112,8 +112,8 @@ class Utils {
      * it doesn't start with these keywords, it will be undetectable by ApexDoc2.
     */
     public static containsScope(line: string): string | null {
-        for (let i = 0; i < ApexDoc.registerScope.length; i++) {
-            let scope = ApexDoc.registerScope[i].toLowerCase();
+        for (let i = 0; i < ApexDoc.config.scope.length; i++) {
+            let scope = ApexDoc.config.scope[i].toLowerCase();
 
             // if line starts with annotations, replace them, so
             // we can accurately use startsWith to match scope.

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,10 @@
   dependencies:
     "@types/node" "*"
 
+"@types/pretty@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/@types/pretty/-/pretty-2.0.0.tgz#4e8ce2f200db5de424791d0bc8d023f24ff312a9"
+
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
@@ -95,6 +99,10 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+abbrev@1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
 accepts@~1.3.5:
   version "1.3.5"
@@ -266,9 +274,28 @@ commander@^2.12.1:
   version "2.19.0"
   resolved "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
+commander@^2.19.0:
+  version "2.20.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+
+condense-newlines@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/condense-newlines/-/condense-newlines-0.2.1.tgz#3de985553139475d32502c83b02f60684d24c55f"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-whitespace "^0.3.0"
+    kind-of "^3.0.2"
+
+config-chain@^1.1.12:
+  version "1.1.12"
+  resolved "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz#0fde8d091200eb5e808caf25fe618c02f48e4efa"
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -340,6 +367,15 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+editorconfig@^0.15.2:
+  version "0.15.3"
+  resolved "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
+  dependencies:
+    commander "^2.19.0"
+    lru-cache "^4.1.5"
+    semver "^5.6.0"
+    sigmund "^1.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -413,6 +449,12 @@ express@^4.16.4:
     type-is "~1.6.16"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
 
 extend@~3.0.2:
   version "3.0.2"
@@ -579,13 +621,29 @@ inherits@2, inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+ini@^1.3.4:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
+
 ipaddr.js@1.8.0:
   version "1.8.0"
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz#eaa33d6ddd7ace8f7f6fe0c9ca0440e706738b1e"
 
+is-buffer@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-extendable@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
 is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
+is-whitespace@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -594,6 +652,16 @@ is-wsl@^1.1.0:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+js-beautify@^1.6.12:
+  version "1.9.1"
+  resolved "https://registry.npmjs.org/js-beautify/-/js-beautify-1.9.1.tgz#6f9ef915f5d8d92b9f907606fce63795884c8040"
+  dependencies:
+    config-chain "^1.1.12"
+    editorconfig "^0.15.2"
+    glob "^7.1.3"
+    mkdirp "~0.5.0"
+    nopt "~4.0.1"
 
 js-tokens@^3.0.2:
   version "3.0.2"
@@ -631,9 +699,22 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+kind-of@^3.0.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
 lodash.escape@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+
+lru-cache@^4.1.5:
+  version "4.1.5"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -671,7 +752,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -704,6 +785,13 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+nopt@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
+
 oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -726,6 +814,21 @@ open@^6.0.0:
   dependencies:
     is-wsl "^1.1.0"
 
+os-homedir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+
+os-tmpdir@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+osenv@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
+
 parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
@@ -746,12 +849,28 @@ performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
 
+pretty@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/pretty/-/pretty-2.0.0.tgz#adbc7960b7bbfe289a557dc5f737619a220d06a5"
+  dependencies:
+    condense-newlines "^0.2.1"
+    extend-shallow "^2.0.1"
+    js-beautify "^1.6.12"
+
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+
 proxy-addr@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.8.0"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
   version "1.1.31"
@@ -839,6 +958,10 @@ semver@^5.3.0, semver@^5.4.1:
   version "5.6.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
+semver@^5.6.0:
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
+
 send@0.16.2:
   version "0.16.2"
   resolved "https://registry.npmjs.org/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
@@ -869,6 +992,10 @@ serve-static@1.13.2:
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+
+sigmund@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz#3ff21f198cad2175f9f3b781853fd94d0d19b590"
 
 source-map-support@^0.5.0:
   version "0.5.11"
@@ -1044,3 +1171,7 @@ vscode@^1.1.28:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"


### PR DESCRIPTION
Add an assets folder to output for JS, CSS, favicon and any other assets user specifies.

Also a few other improvements:

- prettify output for readable HTML
- refactor config validations so it takes place directly after config merge, not at the beginning of apexdoc run. Also store config object as a static on ApexDoc class, so all config vars can be easily accessed from anywhere in the program as needed.
- fix bug in backtick / code tag replacement code
- fix bug that was returning undefined models for class level enums
- round stopwatch output to two decimal places